### PR TITLE
Updated project URL in installation message to current location.

### DIFF
--- a/messages/install.txt
+++ b/messages/install.txt
@@ -7,4 +7,4 @@ This linter plugin for SublimeLinter provides an interface to cppcheck.
 Before this plugin will activate, you *must*
 follow the installation instructions here:
 
-https://github.com/NotSqrt/SublimeLinter-cppcheck
+https://github.com/SublimeLinter/SublimeLinter-cppcheck


### PR DESCRIPTION
The URL in the current message redirects correctly, but you may as well use the current one.
