### PR TITLE
Only report errors for current file

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -20,15 +20,12 @@ class Cppcheck(Linter):
     syntax = ('c++', 'c')  # Able to handle C and C++ syntax
     cmd = ('cppcheck', '--template=gcc', '--inline-suppr', '--quiet', '*', '@')
     regex = (
-        r'^.+:(?P<line>\d+):\s+'
+        r'^(?P<file>.+):(?P<line>\d+):\s+'
         r'((?P<error>error)|(?P<warning>warning|style|performance|portability|information)):\s+'
         r'(?P<message>.+)'
     )
     error_stream = util.STREAM_BOTH  # linting errors are on stderr, exceptions like "file not found" on stdout
-    tempfile_suffix = {
-        'c++': 'cpp',
-        'c': 'c'
-    }
+    tempfile_suffix = '-'
     defaults = {
         '--std=,+': [],  # example ['c99', 'c89']
         '--enable=,': 'style',
@@ -37,3 +34,18 @@ class Cppcheck(Linter):
     inline_overrides = 'enable'
 
     comment_re = r'\s*/[/*]'
+
+    def split_match(self, match):
+        """
+        Return the components of the match.
+
+        We override this because included header files can cause linter errors,
+        and we only want errors from the linted file.
+
+        """
+
+        if match:
+            if match.group('file') != self.filename:
+                match = None
+
+        return super().split_match(match)


### PR DESCRIPTION
Make this linter [file-only](http://www.sublimelinter.com/en/latest/linter_attributes.html?highlight=tempfile_suffix#file-only-linters) so we can exclude errors in other files.

Fixes #3
Fixes SublimeLinter/SublimeLinter3#228