### PR TITLE
Update for SL4

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -45,6 +45,6 @@ class Cppcheck(Linter):
 
         if match:
             if match.group('file') != self.filename:
-                match = None
+                return None
 
         return super().split_match(match)


### PR DESCRIPTION
There is no need to call `split_match` with None, it doesn't make
a fancy error out of thin air, just return early.

Fixes #13 