### PR TITLE
Use explicit template instead of 'gcc'

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,14 @@ from SublimeLinter.lint import Linter, util
 
 
 class Cppcheck(Linter):
-    cmd = ('cppcheck', '--template={file}:{line}: {severity}: {message}', '--inline-suppr', '--quiet', '${args}', '${file}')
+    cmd = (
+        'cppcheck',
+        '--template={file}:{line}: {severity}: {message}',
+        '--inline-suppr',
+        '--quiet',
+        '${args}',
+        '${file}'
+    )
     regex = (
         r'^(?P<file>(:\\|[^:])+):(?P<line>\d+):((?P<col>\d+):)?\s+'
         r'((?P<error>error)|(?P<warning>warning|style|performance|portability|information)):\s+'

--- a/linter.py
+++ b/linter.py
@@ -4,16 +4,16 @@ from SublimeLinter.lint import Linter, util
 class Cppcheck(Linter):
     cmd = (
         'cppcheck',
-        '--template={file}:{line}: {severity}: {message}',
+        '--template={file}:{line}:{column}:{severity}:{id}:{message}',
         '--inline-suppr',
         '--quiet',
         '${args}',
         '${file}'
     )
     regex = (
-        r'^(?P<file>(:\\|[^:])+):(?P<line>\d+):((?P<col>\d+):)?\s+'
-        r'((?P<error>error)|(?P<warning>warning|style|performance|portability|information)):\s+'
-        r'(?P<message>.+)'
+        r'^(?P<file>(:\\|[^:])+):(?P<line>\d+):((?P<col>\d+):)'
+        r'((?P<error>error)|(?P<warning>warning|style|performance|portability|information)):'
+        r'(?P<code>\w+):(?P<message>.+)'
     )
     error_stream = util.STREAM_BOTH  # linting errors are on stderr, exceptions like "file not found" on stdout
     on_stderr = None  # handle stderr via split_match

--- a/linter.py
+++ b/linter.py
@@ -2,7 +2,7 @@ from SublimeLinter.lint import Linter, util
 
 
 class Cppcheck(Linter):
-    cmd = ('cppcheck', '--template=gcc', '--inline-suppr', '--quiet', '${args}', '${file}')
+    cmd = ('cppcheck', '--template={file}:{line}: {severity}: {message}', '--inline-suppr', '--quiet', '${args}', '${file}')
     regex = (
         r'^(?P<file>(:\\|[^:])+):(?P<line>\d+):((?P<col>\d+):)?\s+'
         r'((?P<error>error)|(?P<warning>warning|style|performance|portability|information)):\s+'


### PR DESCRIPTION
cppcheck 1.84 changed the meaning of --template=gcc to add a second line of output that confuses the linter plugin, so explicitly request the old format

see https://github.com/danmar/cppcheck/commit/f058d9ad083a6111e9339b4b3506c5da7db579e0 for the details of that change